### PR TITLE
Fix signature import and make automatic_tax overridable

### DIFF
--- a/faststripe/core.py
+++ b/faststripe/core.py
@@ -9,7 +9,7 @@ __all__ = ['stripe_api_url', 'names', 'op2nm', 'StripeApi', 'paged', 'pages']
 from fastcore.all import *
 from .endpoints import eps
 from .spec import docs_url
-from inspect import Parameter, Signature
+from inspect import Parameter, Signature, signature
 from urllib.parse import quote
 
 import re
@@ -171,9 +171,10 @@ def priced_product(self:StripeApi, product_name, amount_cents, currency='usd', r
 @delegates(StripeApi().checkout.sessions_post)
 def one_time_payment(self:StripeApi, product_name, amount_cents, success_url, cancel_url, currency='usd', quantity=1, **kwargs):
     'Create a simple one-time payment checkout'
+    automatic_tax = kwargs.pop('automatic_tax', {'enabled': True})
     _, price = self.priced_product(product_name, amount_cents, currency)
     return self.checkout.sessions_post(mode='payment', line_items=[dict(price=price.id, quantity=quantity)],
-                                       automatic_tax={'enabled': True}, success_url=success_url, cancel_url=cancel_url, **kwargs)
+                                       automatic_tax=automatic_tax, success_url=success_url, cancel_url=cancel_url, **kwargs)
 
 # %% ../nbs/01_core.ipynb 63
 @patch

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -31,7 +31,7 @@
     "from fastcore.all import *\n",
     "from faststripe.endpoints import eps\n",
     "from faststripe.spec import docs_url\n",
-    "from inspect import Parameter, Signature\n",
+    "from inspect import Parameter, Signature, signature\n",
     "from urllib.parse import quote\n",
     "\n",
     "import re"
@@ -1114,9 +1114,10 @@
     "@delegates(StripeApi().checkout.sessions_post)\n",
     "def one_time_payment(self:StripeApi, product_name, amount_cents, success_url, cancel_url, currency='usd', quantity=1, **kwargs):\n",
     "    'Create a simple one-time payment checkout'\n",
+    "    automatic_tax = kwargs.pop('automatic_tax', {'enabled': True})\n",
     "    _, price = self.priced_product(product_name, amount_cents, currency)\n",
     "    return self.checkout.sessions_post(mode='payment', line_items=[dict(price=price.id, quantity=quantity)],\n",
-    "                                       automatic_tax={'enabled': True}, success_url=success_url, cancel_url=cancel_url, **kwargs)"
+    "                                       automatic_tax=automatic_tax, success_url=success_url, cancel_url=cancel_url, **kwargs)"
    ]
   },
   {


### PR DESCRIPTION
Two fixes:

1. **Missing `signature` import** — `__str__` uses `signature(self)` but only `Signature` (class) was imported, not `signature` (function).

2. **`automatic_tax` now overridable** — Changed from hardcoded `automatic_tax={'enabled': True}` to `kwargs.pop('automatic_tax', {'enabled': True})` so users can override it with `automatic_tax={'enabled': False}` if they don't have tax settings configured.