### PR TITLE
Update Stripe spec to 2026-05-27: new payment methods, webhook verifier improvements, and API enhancements

### DIFF
--- a/faststripe/__init__.py
+++ b/faststripe/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2026.04.22.1"
+__version__ = "2026.05.27.0"
 from .core import *
 

--- a/faststripe/core.py
+++ b/faststripe/core.py
@@ -18,7 +18,7 @@ from .stripe_spec import sspec
 import json,hmac,hashlib,time,re,httpx
 
 # %% ../nbs/01_core.ipynb #1db6b434
-def stripe_group(oid, path, verb):
+def stripe_group(oid, path, verb, ptags, optags):
     return [s[1:-1] if s.startswith('{') and s.endswith('}') else s for s in path.strip('/').split('/')], verb
 
 sspec = dict2obj(sspec)
@@ -113,18 +113,20 @@ async def pages(oper, *args, **kwargs):
     "Retrieve all items from all pages of a Stripe API operation."
     return L([x async for page in paged(oper, *args, **kwargs) for x in page.data])
 
-# %% ../nbs/01_core.ipynb #05a5095b
+# %% ../nbs/01_core.ipynb #a5730b15
 def verify_webhook(payload, sig_header, secret, tolerance=300):
-    "Verify a Stripe webhook signature. Raises StripeSignatureError on failure."
+    "Verify a Stripe webhook signature, accepting any of multiple v1 entries"
     if hasattr(payload, 'decode'): payload = payload.decode('utf-8')
-    try: parts = dict(p.split('=', 1) for p in sig_header.split(','))
-    except Exception: raise StripeSignatureError("Unable to parse signature header")
-    t, v1 = parts.get('t'), parts.get('v1')
-    if not t or not v1: raise StripeSignatureError("No v1 signature found in header")
-    signed = f"{t}.{payload}"
-    expected = hmac.new(secret.encode(), signed.encode(), hashlib.sha256).hexdigest()
-    if not hmac.compare_digest(expected, v1): raise StripeSignatureError("Signature mismatch")
-    if (time.time() - int(t)) > tolerance: raise StripeSignatureError("Timestamp outside tolerance zone")
+    parts = [p.split('=', 1) for p in sig_header.split(',')]
+    if any(len(p) != 2 for p in parts): raise StripeSignatureError('Unable to parse signature header')
+    t = next((v for k,v in parts if k=='t'), None)
+    v1s = [v for k,v in parts if k=='v1']
+    if not t or not v1s: raise StripeSignatureError('No v1 signature found in header')
+    exp = hmac.new(secret.encode(), f'{t}.{payload}'.encode(), hashlib.sha256).hexdigest()
+    if not any(hmac.compare_digest(exp, v) for v in v1s): raise StripeSignatureError('Signature mismatch')
+    try: age = time.time() - int(t)
+    except Exception: raise StripeSignatureError('Invalid timestamp')
+    if age > tolerance: raise StripeSignatureError('Timestamp outside tolerance zone')
     return True
 
 # %% ../nbs/01_core.ipynb #0070850f

--- a/nbs/00_spec.ipynb
+++ b/nbs/00_spec.ipynb
@@ -59,7 +59,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Updated version to 2026.04.22.0\n"
+      "Updated version to 2026.05.27.0\n"
      ]
     }
    ],

--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def stripe_group(oid, path, verb):\n",
+    "def stripe_group(oid, path, verb, ptags, optags):\n",
     "    return [s[1:-1] if s.startswith('{') and s.endswith('}') else s for s in path.strip('/').split('/')], verb\n",
     "\n",
     "sspec = dict2obj(sspec)\n",
@@ -262,7 +262,7 @@
     {
      "data": {
       "text/markdown": [
-       "<div class=\"prose\">\n",
+       "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
        "Account(id=acct_1Q4H44KGhqIw9PXm)\n",
@@ -330,7 +330,7 @@
     {
      "data": {
       "text/plain": [
-       "('prod_UWs27UXlTGYChz', 'Test Product')"
+       "('prod_UbdvjLmvG6gLqD', 'Test Product')"
       ]
      },
      "execution_count": null,
@@ -374,7 +374,7 @@
     {
      "data": {
       "text/plain": [
-       "('price_1TXoIiKGhqIw9PXmy2XmL9tW', 1000, 'usd')"
+       "('price_1TcQddKGhqIw9PXmRQn6J4Kb', 1000, 'usd')"
       ]
      },
      "execution_count": null,
@@ -405,7 +405,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Payment link: https://billing.answer.ai/c/pay/cs_test_a1s18jaLGK2ANzSVD7EAxI2O...\n"
+      "Payment link: https://billing.answer.ai/c/pay/cs_test_a1covGnywAwhXKG7huU7H0Ud...\n"
      ]
     }
    ],
@@ -508,7 +508,7 @@
     {
      "data": {
       "text/plain": [
-       "(588,\n",
+       "(593,\n",
        " dict_keys(['id', 'object', 'amount_off', 'created', 'currency', 'duration', 'duration_in_months', 'livemode', 'max_redemptions', 'metadata', 'name', 'percent_off', 'redeem_by', 'times_redeemed', 'valid']))"
       ]
      },
@@ -551,7 +551,16 @@
    "execution_count": null,
    "id": "5c5c75fb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/natedawg/aai-ws/fasthtml/fasthtml/jupyter.py:136: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.\n",
+      "  from starlette.testclient import TestClient\n"
+     ]
+    }
+   ],
    "source": [
     "from fasthtml.common import *\n",
     "from fasthtml.jupyter import *"
@@ -614,22 +623,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05a5095b",
+   "id": "a5730b15",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
     "def verify_webhook(payload, sig_header, secret, tolerance=300):\n",
-    "    \"Verify a Stripe webhook signature. Raises StripeSignatureError on failure.\"\n",
+    "    \"Verify a Stripe webhook signature, accepting any of multiple v1 entries\"\n",
     "    if hasattr(payload, 'decode'): payload = payload.decode('utf-8')\n",
-    "    try: parts = dict(p.split('=', 1) for p in sig_header.split(','))\n",
-    "    except Exception: raise StripeSignatureError(\"Unable to parse signature header\")\n",
-    "    t, v1 = parts.get('t'), parts.get('v1')\n",
-    "    if not t or not v1: raise StripeSignatureError(\"No v1 signature found in header\")\n",
-    "    signed = f\"{t}.{payload}\"\n",
-    "    expected = hmac.new(secret.encode(), signed.encode(), hashlib.sha256).hexdigest()\n",
-    "    if not hmac.compare_digest(expected, v1): raise StripeSignatureError(\"Signature mismatch\")\n",
-    "    if (time.time() - int(t)) > tolerance: raise StripeSignatureError(\"Timestamp outside tolerance zone\")\n",
+    "    parts = [p.split('=', 1) for p in sig_header.split(',')]\n",
+    "    if any(len(p) != 2 for p in parts): raise StripeSignatureError('Unable to parse signature header')\n",
+    "    t = next((v for k,v in parts if k=='t'), None)\n",
+    "    v1s = [v for k,v in parts if k=='v1']\n",
+    "    if not t or not v1s: raise StripeSignatureError('No v1 signature found in header')\n",
+    "    exp = hmac.new(secret.encode(), f'{t}.{payload}'.encode(), hashlib.sha256).hexdigest()\n",
+    "    if not any(hmac.compare_digest(exp, v) for v in v1s): raise StripeSignatureError('Signature mismatch')\n",
+    "    try: age = time.time() - int(t)\n",
+    "    except Exception: raise StripeSignatureError('Invalid timestamp')\n",
+    "    if age > tolerance: raise StripeSignatureError('Timestamp outside tolerance zone')\n",
     "    return True"
    ]
   },
@@ -770,16 +781,16 @@
     {
      "data": {
       "text/markdown": [
-       "<div class=\"prose\">\n",
+       "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
-       "PaymentIntent(id=pi_3TXoJMKGhqIw9PXm0tIX6jVa)\n",
+       "PaymentIntent(id=pi_3TcQdzKGhqIw9PXm1M6IXQEq)\n",
        "```\n",
        "\n",
        "</div>"
       ],
       "text/plain": [
-       "PaymentIntent(id=pi_3TXoJMKGhqIw9PXm0tIX6jVa)"
+       "PaymentIntent(id=pi_3TcQdzKGhqIw9PXm1M6IXQEq)"
       ]
      },
      "execution_count": null,
@@ -790,7 +801,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Event(id=evt_3TXoJMKGhqIw9PXm0UIFzrM6) PaymentIntent(id=pi_3TXoJMKGhqIw9PXm0tIX6jVa)\n"
+      "Event(id=evt_3TcQdzKGhqIw9PXm1cJa318w) PaymentIntent(id=pi_3TcQdzKGhqIw9PXm1M6IXQEq)\n"
      ]
     }
    ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "ncoop57", email = "nathanacooper@proton.me"}]
 keywords = ['nbdev', 'jupyter', 'notebook', 'python']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 3 - Alpha", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastcore', 'fastspec>=0.0.5', 'httpx', 'nbdev>=3']
+dependencies = ['fastcore', 'fastspec>=0.0.6', 'httpx', 'nbdev>=3']
 
 [project.urls]
 Repository = "https://github.com/AnswerDotAI/faststripe"


### PR DESCRIPTION
## Summary

Updates the Stripe API spec from `2026-04-22.dahlia` to `2026-05-27.dahlia` and improves the webhook signature verifier.

## Changes

### Core
- **Webhook verifier**: Now accepts multiple `v1` signature entries in the header, adds invalid timestamp error handling, and improves parse error detection
- **`stripe_group`**: Updated signature to accept `ptags` and `optags` parameters

### New Payment Methods
- **Bizum**: Spanish IBAN-based mobile payment method
- **Scalapay**: Buy-now-pay-later in 3 or 4 installments

### API Enhancements
- **Subscriptions**: New `billing_schedules` field; `cancel_at` gains `max_billed_until` option; `discounts` behavior clarified; `payment_behavior` descriptions
simplified; `billing_schedules` encoding added
- **Payment Intents / Setup Intents**: `transfer_data` gains `description`, `metadata`, and `payment_data` fields; `bizum`/`scalapay` options added
- **Checkout Sessions**: `ui_mode` default clarified to `hosted_page`; `custom` references updated to `elements`
- **Payment Links**: New `payment_method_options` with card brand blocking support
- **Terminal**: New Verifone reader models (M425, P630, UX700, V660p); reader action gains `api_error` and `print_content`; `/v1/terminal/refunds` simplified
- **Twint**: `setup_future_usage` now supports `off_session`; mandate support added
- **Mandates**: `twint` mandate type added
- **Invoices**: New `amount_paid_off_stripe` field; proration `credited_items` added
- **Balance Settings**: New `automatic_transfer_rules_by_currency` and `start_of_day` fields
- **Test Clocks**: New `customer` parameter on creation
- **Webhooks**: `2026-05-27.dahlia` API version added
- **Dependency**: `fastspec` bumped to `>=0.0.6`